### PR TITLE
add repository url to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.3"
 edition = "2021"
 description = "A client for spicedb"
 keywords = ["spicedb", "authzed", "authorization"]
+repository = "https://github.com/Lur1an/spicedb-rust"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
I found it is inconvenient that https://crates.io/crates/spicedb-rust doesn't show the link to this repo. 